### PR TITLE
Reset stream before reading

### DIFF
--- a/src/NovoNordisk.Configuration.AzureBlob/BlobJsonConfigurationProvider.cs
+++ b/src/NovoNordisk.Configuration.AzureBlob/BlobJsonConfigurationProvider.cs
@@ -31,6 +31,7 @@ public class BlobJsonConfigurationProvider : ConfigurationProvider, IDisposable,
         var client = GetBlobClient();
         using var stream = new MemoryStream();
         using var response = await client.DownloadToAsync(stream);
+        stream.Seek(0, SeekOrigin.Begin);
 
         if (!response.IsError)
         {


### PR DESCRIPTION
The memory stream was not reset to the beginning before reading, leading to empty stream when trying to read.